### PR TITLE
Added default value for "value" parameter

### DIFF
--- a/dsl.md
+++ b/dsl.md
@@ -177,7 +177,7 @@ class Config
   end
 
   def method_missing(name, *args)
-    self.singleton_class.send(:define_method, name) do |value|
+    self.singleton_class.send(:define_method, name) do |value=nil|
       return instance_variable_get("@#{name}") unless value
       instance_variable_set("@#{name}", value.size == 1 ? value[0] : value)
     end


### PR DESCRIPTION
In this example work only "setters" methods.(for example config.port(9999))
If you try to get something(for example config.port) you'll have an  ArgumentError
`block in method_missing': wrong number of arguments (given 0, expected 1) (ArgumentError)

to fix it I added default value for block parametr